### PR TITLE
Added support for adding teams to existing ideas

### DIFF
--- a/back-end/.gitignore
+++ b/back-end/.gitignore
@@ -2,3 +2,4 @@
 firebase_tester.py
 .env
 ServiceAccountPrivateKey.json
+Changes.txt


### PR DESCRIPTION

- Back-end has now been confiured to add new teams to existing ideas in
the database.
- Added 'name' field for teams inside teams section in the database and
made changes in the codebase accordingly to work with the changed
database structure.
- Added a check in `get_idea_info` function for checking if idea_ID
requested is invalid.
- Added methods `update_idea` and `update_team` in `Refs` class to
update info about existing ideas and teams respectively.